### PR TITLE
fix(calendarStrip.js): add update for selectdDate on start

### DIFF
--- a/lib/CalendarStrip.js
+++ b/lib/CalendarStrip.js
@@ -112,15 +112,6 @@ class CalendarStrip extends Component {
         || !isEqual(nextProps.currentDropdownValue, this.props.currentDropdownValue);
   }
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    console.log(JSON.stringify({
-      prevProps,
-      prevState,
-      props: this.props,
-      state: this.state
-    }, null, 2));
-  }
-
   componentWillReceiveProps(nextProps) {
     const nextSelectedDate = nextProps.selectedDate;
     let nextPage;
@@ -311,10 +302,7 @@ class CalendarStrip extends Component {
           {this._renderHeader()}
           <Weeks header={header} selectedDate={selectedDate}/>
           <FlatList
-              ref={ref => {
-                this._calendar = ref;
-                // this.props.onGetRef(ref);
-              }}
+              ref={ref => this._calendar = ref}
               bounces={false}
               horizontal
               pagingEnabled

--- a/lib/CalendarStrip.js
+++ b/lib/CalendarStrip.js
@@ -103,14 +103,22 @@ class CalendarStrip extends Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    return !isSameDay(nextProps.selectedDate, this.props.selectedDate)
-        || !isEqual(nextProps.emptyDays, this.props.emptyDays)
+    return !isEqual(nextProps.emptyDays, this.props.emptyDays)
         || !isEqual(nextProps.filtersActive, this.props.filtersActive)
         || !isEqual(nextProps.backgroundOffset, this.props.backgroundOffset)
         || !isEqual(nextState.datas, this.state.datas)
         || !isEqual(nextState.header, this.state.header)
         || !isEqual(nextState.currentDropdownValue, this.state.currentDropdownValue)
         || !isEqual(nextProps.currentDropdownValue, this.props.currentDropdownValue);
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    console.log(JSON.stringify({
+      prevProps,
+      prevState,
+      props: this.props,
+      state: this.state
+    }, null, 2));
   }
 
   componentWillReceiveProps(nextProps) {
@@ -141,7 +149,6 @@ class CalendarStrip extends Component {
           });
         }
       }
-      if (isSameDay(nextProps.selectedDate, this.props.selectedDate)) return;
       this.scrollToPage(nextPage);
     }
     if (this.props.currentDropdownValue !== nextProps.currentDropdownValue) {
@@ -304,7 +311,10 @@ class CalendarStrip extends Component {
           {this._renderHeader()}
           <Weeks header={header} selectedDate={selectedDate}/>
           <FlatList
-              ref={ref => this._calendar = ref}
+              ref={ref => {
+                this._calendar = ref;
+                // this.props.onGetRef(ref);
+              }}
               bounces={false}
               horizontal
               pagingEnabled


### PR DESCRIPTION
fix a bug if you stay on the  second calendar page and leave a screen and go back it start from page 0 which is a bug