### PR TITLE
fix(CalendarStrip.js): fix OS check condition

### DIFF
--- a/lib/CalendarStrip.js
+++ b/lib/CalendarStrip.js
@@ -193,7 +193,7 @@ class CalendarStrip extends Component {
   handleDropdownSelection = () => {
     const {dropdownValues} = this.props;
     const options = dropdownValues.map(({name}) => name);
-    if (Platform.OS = 'ios') {
+    if (Platform.OS === 'ios') {
       ActionSheetIOS.showActionSheetWithOptions({
         title: 'Select your Region',
         options: [


### PR DESCRIPTION
The condition was always truthy, so we called the iOS-specific code regardless of the platform.