### PR TITLE
fix(CalendarStrip.js): handle selection regardless of platform

### DIFF
--- a/lib/CalendarStrip.js
+++ b/lib/CalendarStrip.js
@@ -8,10 +8,9 @@ import {
   StyleSheet,
   PanResponder,
   TouchableOpacity,
-  Animated,
-  ActionSheetIOS,
-  Platform
+  Animated
 } from 'react-native';
+import ActionSheet from 'react-native-actionsheet';
 import Weeks from './Weeks';
 import {
   format,
@@ -190,30 +189,11 @@ class CalendarStrip extends Component {
     return header;
   };
 
-  handleDropdownSelection = () => {
-    const {dropdownValues} = this.props;
-    const options = dropdownValues.map(({name}) => name);
-    if (Platform.OS === 'ios') {
-      ActionSheetIOS.showActionSheetWithOptions({
-        title: 'Select your Region',
-        options: [
-          'Cancel',
-          ...options
-        ],
-        cancelButtonIndex: 0,
-        tintColor: '#000000'
-      }, (buttonIndex) => {
-        if (!buttonIndex) {
-          return;
-        }
-        const correctValue = dropdownValues[buttonIndex - 1];
-        this.setState({
-          currentDropdownValue: correctValue
-        });
-        this.props.onDropdownValueChange(correctValue);
-      })
-    }
-  };
+  openDropdown = () => this.ActionSheet && this.ActionSheet.show();
+
+  handleDropdownSelection = (buttonIndex) => this.props.onDropdownValueChange(
+    this.props.dropdownValues[buttonIndex]
+  );
 
   get _statusBarHeight() {
     return isIphoneX() ? 30 : 21;
@@ -248,7 +228,7 @@ class CalendarStrip extends Component {
             </TouchableOpacity>
           </View>
           <View style={styles.headerWrapper}>
-            <TouchableOpacity style={styles.headerTouchable} onPress={this.handleDropdownSelection}>
+            <TouchableOpacity style={styles.headerTouchable} onPress={this.openDropdown}>
               <Text style={styles.headerDate}>
                 {this.state.header} IN {currentDropdownValue.shortName}
               </Text>
@@ -286,11 +266,25 @@ class CalendarStrip extends Component {
   render() {
     const {isCurrentWeek} = this.state;
     const {
+      dropdownValues,
       emptyDays,
       onPressDate,
       selectedDate
     } = this.props;
+    const options = [
+      ...dropdownValues.map(({name}) => name),
+      'Cancel',
+    ];
     return (
+      <React.Fragment>
+        <ActionSheet
+          ref={(sheet) => this.ActionSheet = sheet}
+          title={'Select your Region'}
+          options={options}
+          cancelButtonIndex={options.length - 1}
+          tintColor={'#000000'}
+          onPress={this.handleDropdownSelection}
+        />
         <Animated.View
             style={[styles.container, {
               transform: [{
@@ -333,6 +327,7 @@ class CalendarStrip extends Component {
               }
           />
         </Animated.View>
+      </React.Fragment>
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -810,6 +810,11 @@
       "integrity": "sha512-WUSQJ4P/wWcusaH+zZmbECOk7H5N2pOIl0vzheeornkIMhu+qrNdGFm0bDZLCb0hSF0jf/kH1SgkNGfBdTc4wA==",
       "dev": true
     },
+    "react-native-actionsheet": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/react-native-actionsheet/-/react-native-actionsheet-2.4.2.tgz",
+      "integrity": "sha512-DBoWIvVwuWXuptF4t46pBqkFxaUxS+rsIdHiA05t0n4BdTIDV2R4s9bLEUVOGzb94D7VxIamsXZPA/3mmw+SXg=="
+    },
     "react-proxy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/react-proxy/-/react-proxy-1.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "dependencies": {
     "date-fns": "^1.29.0",
     "date-fns-timezone": "^0.1.4",
-    "lodash.isequal": "^4.5.0"
+    "lodash.isequal": "^4.5.0",
+    "react-native-actionsheet": "^2.4.2"
   },
   "peerDependencies": {
     "react": ">= 15.x",


### PR DESCRIPTION
The dropdown selection for Android was not implemented at all. By using `react-native-actionsheet`, we can automagically selection regardless of the platform.